### PR TITLE
Feat/user create 24

### DIFF
--- a/config-service/src/main/resources/config-repository/user-service-dev.yml
+++ b/config-service/src/main/resources/config-repository/user-service-dev.yml
@@ -13,9 +13,13 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
+
+jwt:
+  secret: ${JWT_KEY}
+  expiration: 60m

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -30,13 +30,18 @@ ext {
 }
 
 dependencies {
-    implementation 'com.github.GBG-Gaboja-Go:gabojago-common:1.0.5'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'com.github.GBG-Gaboja-Go:gabojago-common:1.0.7'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/user-service/src/main/java/com/gbg/userservice/application/service/AuthService.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.gbg.userservice.application.service;
+
+import com.gbg.userservice.presentation.dto.request.CreateUserRequestDto;
+import java.util.UUID;
+
+public interface AuthService {
+
+    UUID signUp(CreateUserRequestDto req);
+}

--- a/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
@@ -1,5 +1,9 @@
 package com.gbg.userservice.application.service;
 
+import com.gbg.userservice.presentation.dto.response.UserResponseDto;
+import java.util.List;
+
 public interface UserService {
 
+    List<UserResponseDto> getUserList();
 }

--- a/user-service/src/main/java/com/gbg/userservice/application/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/impl/AuthServiceImpl.java
@@ -1,0 +1,67 @@
+package com.gbg.userservice.application.service.impl;
+
+import com.gabojago.exception.AppException;
+import com.gbg.userservice.application.service.AuthService;
+import com.gbg.userservice.domain.entity.User;
+import com.gbg.userservice.domain.entity.UserRole;
+import com.gbg.userservice.domain.repository.UserRepository;
+import com.gbg.userservice.infrastructure.exception.UserErrorCode;
+import com.gbg.userservice.presentation.dto.request.CreateUserRequestDto;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UUID signUp(CreateUserRequestDto req) {
+
+        if (req.hasCompanyId()) {
+            User user = User.of(
+                req.username(),
+                req.nickname(),
+                req.slackEmail(),
+                passwordEncoder.encode(req.password()),
+                req.organization(),
+                req.summary());
+            User saveUser = userRepository.save(user);
+            return saveUser.getId();
+        }
+        else {
+            User user = User.of(
+                req.username(),
+                req.nickname(),
+                req.slackEmail(),
+                passwordEncoder.encode(req.password()),
+                req.summary());
+            User saveUser = userRepository.save(user);
+            return saveUser.getId();
+        }
+    }
+
+    private void validateDuplicateUsernameAndSlackEmail(String username, String slackEmail) {
+
+        List <User> users = userRepository.findAllByUsernameOrSlackEmail(username, slackEmail);
+
+        boolean usernameDuplicate = users.stream()
+            .anyMatch(u -> u.getUsername().equals(username));
+
+        if (usernameDuplicate) {
+            throw new AppException(UserErrorCode.USER_DUPLICATE_NAME);
+        }
+
+        boolean slackEmailDuplicate = users.stream()
+            .anyMatch(u -> u.getSlackEmail().equals(slackEmail));
+
+        if (slackEmailDuplicate) {
+            throw new AppException(UserErrorCode.USER_DUPLICATE_EMAIL);
+        }
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
@@ -1,9 +1,33 @@
 package com.gbg.userservice.application.service.impl;
 
 import com.gbg.userservice.application.service.UserService;
+import com.gbg.userservice.domain.entity.User;
+import com.gbg.userservice.domain.repository.UserRepository;
+import com.gbg.userservice.presentation.dto.response.UserResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
+    private final UserRepository userRepository;
+
+    @Override
+    public List<UserResponseDto> getUserList() {
+
+        List<User> userList = userRepository.userList();
+
+        return userList.stream()
+            .map(u -> UserResponseDto.builder()
+                .user(UserResponseDto.UserDto.builder()
+                    .username(u.getUsername())
+                    .nickname(u.getNickname())
+                    .slackEmail(u.getSlackEmail())
+                    .organization(u.getOrganization())
+                    .role(u.getRole())
+                    .build())
+                .build()).toList();
+    }
 }

--- a/user-service/src/main/java/com/gbg/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/gbg/userservice/domain/entity/User.java
@@ -2,18 +2,20 @@ package com.gbg.userservice.domain.entity;
 
 import com.gabojago.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "p_user")
 public class User extends BaseEntity {
 
@@ -25,29 +27,55 @@ public class User extends BaseEntity {
 
     private String nickname;
 
-    private String slackId;
-
-    private String email;
+    private String slackEmail;
 
     private String password;
 
+    private UUID organization;
+
+    private String summary;
+
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    public static User of
-        (String username, String nickname, String slackId, String email,
-            String password, UserRole role)
-    {
-        User user = new User();
-        user.username = username;
-        user.nickname = nickname;
-        user.slackId = slackId;
-        user.email = email;
-        user.password = password;
-        user.role = role;
-        user.status = UserStatus.PENDING;
-        return user;
+    private User(String username, String nickname, String slackEmail, String password, UUID organization, String summary, UserRole role, UserStatus status) {
+        this.username = username;
+        this.nickname = nickname;
+        this.slackEmail = slackEmail;
+        this.password = password;
+        this.organization = organization;
+        this.summary = summary;
+        this.role = role;
+        this.status = status;
+    }
+
+    public static User of(String username, String nickname, String slackEmail, String password, String summary) {
+        return new User(
+            username,
+            nickname,
+            slackEmail,
+            password,
+            new UUID(0L, 0L),
+            summary,
+            UserRole.USER,
+            UserStatus.PENDING
+        );
+    }
+
+    public static User of(String username, String nickname, String slackEmail, String password, UUID organization, String summary) {
+        return new User(
+            username,
+            nickname,
+            slackEmail,
+            password,
+            organization,
+            summary,
+            UserRole.USER,
+            UserStatus.PENDING
+        );
     }
 
 }

--- a/user-service/src/main/java/com/gbg/userservice/domain/entity/UserRole.java
+++ b/user-service/src/main/java/com/gbg/userservice/domain/entity/UserRole.java
@@ -2,8 +2,23 @@ package com.gbg.userservice.domain.entity;
 
 public enum UserRole {
 
-    MASTER,
-    HUN_MANAGER,
-    DELIVERY_MANAGER,
-    SUPPLIER_MANAGER
+    MASTER("ROLE_MASTER"),
+    HUB_MANAGER("ROLE_HUN_MANAGER"),
+    DELIVERY_MANAGER("ROLE_DELIVERY_MANAGER"),
+    SUPPLIER_MANAGER("ROLE_SUPPLIER_MANAGER"),
+    USER("ROLE_USER");
+
+    private final String authority;
+
+    UserRole(String authority) {
+        this.authority = authority;
+    }
+
+    public boolean isAdmin() {
+        return this == MASTER;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
 }

--- a/user-service/src/main/java/com/gbg/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/gbg/userservice/domain/repository/UserRepository.java
@@ -1,8 +1,17 @@
 package com.gbg.userservice.domain.repository;
 
 import com.gbg.userservice.domain.entity.User;
+import com.gbg.userservice.presentation.dto.response.UserResponseDto;
+import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository {
 
     User save(User user);
+
+    List<User> userList();
+
+    List<User> findAllByUsernameOrSlackEmail(String username, String slackEmail);
+
+    Optional<User> findByUserName(String username);
 }

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/CustomAuditAware.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/CustomAuditAware.java
@@ -1,0 +1,39 @@
+package com.gbg.userservice.infrastructure.config;
+
+import com.gbg.userservice.infrastructure.config.auth.CustomUser;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+
+public class CustomAuditAware implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+
+
+        Authentication authentication
+             = SecurityContextHolder.getContext().getAuthentication();
+        System.out.println("[AuditorAware] : authentication : " + authentication);
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            System.out.println("[AuditorAware] 인증 정보가 없거나 인증되지 않은 상태입니다.");
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        System.out.println("[AuditorAware] : principal : " + principal);
+
+        if (principal instanceof CustomUser user) {
+            System.out.println("[AuditorAware] 로그인 사용자 ID : " + user.getId());
+            return Optional.ofNullable(user.getId());
+        }
+
+        System.out.println("[AuditorAware] Principal이 CustomUser 타입이 아닙니다. 현재 타입 : " + (principal != null ? principal.getClass().getName() : "null"));
+        return Optional.empty();
+    }
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/JpaConfig.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/JpaConfig.java
@@ -1,10 +1,18 @@
 package com.gbg.userservice.infrastructure.config;
 
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorProvider() {
+        return new CustomAuditAware();
+    }
 
 }

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package com.gbg.userservice.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gbg.userservice.infrastructure.config.auth.CustomAccessDeniedHandler;
+import com.gbg.userservice.infrastructure.config.auth.CustomAuthenticationEntryPoint;
+import com.gbg.userservice.infrastructure.config.filter.JwtAuthorizationFilter;
+import com.gbg.userservice.infrastructure.config.jwt.JwtTokenProvider;
+import com.gbg.userservice.infrastructure.config.filter.AuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationFilter authenticationFilter(AuthenticationManager authenticationManager) {
+        AuthenticationFilter filter = new AuthenticationFilter(jwtTokenProvider, objectMapper);
+        filter.setAuthenticationManager(authenticationManager);
+        return filter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationFilter filter) throws Exception {
+        System.out.println("SecurityFilterChain 등록 시작");
+
+        return http
+            // JWT는 게이트웨이에서 이미 검증되므로 세션/폼로그인 비활성화
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // 인증 & 인가 설정
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/v1/users/sign-up").permitAll()
+                .requestMatchers("/v1/users/sign-in").permitAll()
+                .requestMatchers("/swagger-ui/**").permitAll()
+                .requestMatchers("/swagger-resources/**").permitAll()
+                .requestMatchers("/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated())
+
+            // 예외 핸들러 (공통 모듈에서 가져온 클래스)
+            .exceptionHandling(ex -> ex
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
+
+            .addFilterBefore(new JwtAuthorizationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+
+            // 로그인 필터 추가
+            .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
+
+            .build();
+    }
+
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomAccessDeniedHandler.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.gbg.userservice.infrastructure.config.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gabojago.exception.ErrorResponse;
+import com.gbg.userservice.infrastructure.exception.UserErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+/**
+ * 인가 실패 시 -
+ * 사용자가 인증은 됐지만 해당 리소스 접근 권한이 없을 때 (403 Forbidden) 발생 하는 상황을
+ * JSON 형식으로 응답하도록 하는 클래스
+ */
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse errorResponse = ErrorResponse.from(UserErrorCode.USER_FORBIDDEN);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomAuthenticationEntryPoint.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.gbg.userservice.infrastructure.config.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gabojago.exception.ErrorResponse;
+import com.gbg.userservice.infrastructure.exception.UserErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+/**
+ * 인증되지 않은 사용자가 보호된 리소스에 접근했을 때 401(Unauthorized) 호출 되는 JSON 응답용 헨들러
+ */
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse errorResponse = ErrorResponse.from(UserErrorCode.USER_UNAUTHORIZED);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomUser.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomUser.java
@@ -1,0 +1,61 @@
+package com.gbg.userservice.infrastructure.config.auth;
+
+import com.gbg.userservice.domain.entity.UserRole;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class CustomUser implements UserDetails {
+
+    private final UUID id;
+    private final String username;
+    private final String password;
+    private final UserRole role;
+
+    public CustomUser(UUID id, String username, String password, UserRole role) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(role.getAuthority()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomUserDetailsService.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/auth/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.gbg.userservice.infrastructure.config.auth;
+
+import com.gabojago.exception.AppException;
+import com.gbg.userservice.domain.entity.User;
+import com.gbg.userservice.domain.repository.UserRepository;
+import com.gbg.userservice.infrastructure.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        User user = userRepository.findByUserName(username).orElseThrow(
+            () -> new AppException(UserErrorCode.USER_NOT_FOUND)
+        );
+
+        return new CustomUser(
+            user.getId(),
+            user.getUsername(),
+            user.getPassword(),
+            user.getRole()
+        );
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/filter/AuthenticationFilter.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/filter/AuthenticationFilter.java
@@ -1,0 +1,77 @@
+package com.gbg.userservice.infrastructure.config.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gabojago.exception.AppException;
+import com.gabojago.exception.ErrorResponse;
+import com.gbg.userservice.domain.entity.UserRole;
+import com.gbg.userservice.infrastructure.config.auth.CustomUser;
+import com.gbg.userservice.infrastructure.config.jwt.JwtTokenProvider;
+import com.gbg.userservice.infrastructure.exception.UserErrorCode;
+import com.gbg.userservice.presentation.dto.request.FormLoginRequestDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String LOGIN_PROCESS_URL = "/v1/users/sign-in";
+
+    public AuthenticationFilter(JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.objectMapper = objectMapper;
+        setFilterProcessesUrl(LOGIN_PROCESS_URL);
+        System.out.println("AuthenticationFilter 초기화 완료 , 경로 + " + LOGIN_PROCESS_URL);
+    }
+
+    public Authentication attemptAuthentication(HttpServletRequest request,
+        HttpServletResponse response) throws AuthenticationException {
+        try {
+            FormLoginRequestDto loginRequest = objectMapper.readValue(request.getInputStream(),
+                FormLoginRequestDto.class);
+
+            UsernamePasswordAuthenticationToken authRequest = UsernamePasswordAuthenticationToken
+                .unauthenticated(loginRequest.username(), loginRequest.password());
+
+            return this.getAuthenticationManager().authenticate(authRequest);
+
+        } catch (Exception e) {
+            System.out.println("로그인 실패 원인 : " + e.getClass().getSimpleName());
+            System.out.println("메시지 : " + e.getMessage());
+            throw new AppException(UserErrorCode.USER_UNAUTHORIZED);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+        HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        UUID id = ((CustomUser) authResult.getPrincipal()).getId();
+        String username = ((CustomUser) authResult.getPrincipal()).getUsername();
+        UserRole role = ((CustomUser) authResult.getPrincipal()).getRole();
+
+        String token = jwtTokenProvider.createToken(id, username, role);
+        response.addHeader(AUTHORIZATION_HEADER, token);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+        HttpServletResponse response, AuthenticationException failed)
+        throws IOException, ServletException {
+
+        response.setStatus(UserErrorCode.USER_UNAUTHORIZED.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.from(UserErrorCode.USER_UNAUTHORIZED);
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/filter/JwtAuthorizationFilter.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,74 @@
+package com.gbg.userservice.infrastructure.config.filter;
+
+import com.gbg.userservice.domain.entity.UserRole;
+import com.gbg.userservice.infrastructure.config.auth.CustomUser;
+import com.gbg.userservice.infrastructure.config.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        System.out.println("필터 진입 : " + request.getRequestURI());
+
+//        // 이미 인증된 사용자인 경우 필터 통과
+//        Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
+//
+//        if (existingAuth != null && existingAuth.isAuthenticated()) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
+
+        String token = jwtTokenProvider.resolveToken(request);
+
+        // 토큰이 없는 경우 (회원 가입, 로그인)
+        if (token == null || token.isBlank()) {
+            filterChain.doFilter(request,response);
+            return;
+        }
+
+        // 토큰에서 사용자 정보 추출
+        UUID id = jwtTokenProvider.getId(token);
+        String username = jwtTokenProvider.getUsername(token);
+        String role = jwtTokenProvider.getRole(token);
+        UserRole userRole = UserRole.valueOf(role);
+
+        // CustomUser 생성 (UserDetails 구현체)
+        CustomUser customUser = new CustomUser(id, username, null, userRole);
+
+        // 인증 객체 생성
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                customUser,
+                null,
+                customUser.getAuthorities()
+            );
+
+        authentication.setDetails(
+            new WebAuthenticationDetailsSource().buildDetails(request)
+        );
+
+        // SecurityContext에 등록 (권한 확인 가능)
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/config/jwt/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package com.gbg.userservice.infrastructure.config.jwt;
+
+import com.gbg.userservice.domain.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key key;
+
+    @Value("${jwt.expiration}")
+    private Duration validity;
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @PostConstruct
+    private void getSigningKey() {
+        byte[] bytes = secret.getBytes(StandardCharsets.UTF_8);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(UUID id, String username, UserRole roles) {
+        Claims claims = Jwts.claims().setSubject(id.toString());
+        claims.put("username", username);
+        claims.put("roles", roles.toString());
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validity.toMillis());
+
+        return BEARER_PREFIX + Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(expiration)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+
+    public String getUsername(String token) {
+        return parseClaims(token)
+            .get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return parseClaims(token)
+            .get("roles", String.class);
+    }
+
+    public UUID getId(String token) {
+        return UUID.fromString(parseClaims(token).getSubject());
+    }
+
+
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/exception/UserErrorCode.java
@@ -1,0 +1,27 @@
+package com.gbg.userservice.infrastructure.exception;
+
+import com.gabojago.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements ErrorCode {
+
+    USER_UNAUTHORIZED("USER000", "사용자 인증에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("USER001", "해당 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USER_DUPLICATE_NAME("USER002", "이미 사용중인 ID 입니다.", HttpStatus.CONFLICT),
+    USER_DUPLICATE_EMAIL("USER003", "이미 사용중인 Email 입니다.", HttpStatus.CONFLICT),
+    USER_FORBIDDEN("USER004", "사용자 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    SELF_ROLE_UPDATE("USER005", "사용자 권한은 직접 변경할 수 없습니다.", HttpStatus.CONFLICT)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    UserErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserJpaRepository.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserJpaRepository.java
@@ -1,8 +1,13 @@
 package com.gbg.userservice.infrastructure.repository;
 
 import com.gbg.userservice.domain.entity.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
+    List<User> findAllByUsernameOrSlackEmail(String username, String slackEmail);
+
+    Optional<User> findByUsername(String username);
 }

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.gbg.userservice.infrastructure.repository;
 
 import com.gbg.userservice.domain.entity.User;
 import com.gbg.userservice.domain.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +17,23 @@ public class UserRepositoryImpl implements UserRepository {
     public User save(User user) {
 
         return userJpaRepository.save(user);
+    }
+
+    @Override
+    public List<User> userList() {
+
+        return userJpaRepository.findAll();
+    }
+
+    @Override
+    public List<User> findAllByUsernameOrSlackEmail(String username, String slackEmail) {
+
+        return userJpaRepository.findAllByUsernameOrSlackEmail(username, slackEmail);
+    }
+
+    @Override
+    public Optional<User> findByUserName(String username) {
+
+        return userJpaRepository.findByUsername(username);
     }
 }

--- a/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
@@ -1,16 +1,46 @@
 package com.gbg.userservice.presentation.controller;
 
+import com.gabojago.dto.BaseResponseDto;
+import com.gbg.userservice.application.service.AuthService;
+import com.gbg.userservice.application.service.UserService;
+import com.gbg.userservice.infrastructure.config.auth.CustomUser;
+import com.gbg.userservice.presentation.dto.request.CreateUserRequestDto;
+import com.gbg.userservice.presentation.dto.response.UserResponseDto;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v1/users")
 public class UserController {
 
-    @GetMapping
-    public String test() {
+    private final AuthService authService;
+    private final UserService userService;
 
-        return "Users Controller Test!";
+    @PostMapping("/sign-up")
+    public ResponseEntity<BaseResponseDto<UUID>> signUp(
+        @Valid @RequestBody CreateUserRequestDto req
+    ) {
+        UUID saveUser = authService.signUp(req);
+
+        return ResponseEntity.ok(BaseResponseDto.success("회원가입이 완료 되었습니다", saveUser));
     }
+
+    @GetMapping
+    public ResponseEntity<BaseResponseDto<List<UserResponseDto>>> userList() {
+
+        List<UserResponseDto> userList = userService.getUserList();
+
+        return ResponseEntity.ok(BaseResponseDto.success("조회 성공", userList));
+    }
+
 }

--- a/user-service/src/main/java/com/gbg/userservice/presentation/dto/request/CreateUserRequestDto.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/dto/request/CreateUserRequestDto.java
@@ -1,0 +1,37 @@
+package com.gbg.userservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CreateUserRequestDto(
+
+    @NotNull(message = "사용자 이름은 반드시 입력해야 합니다.")
+    String username,
+
+    @Size(max = 20)
+    String nickname,
+
+    @NotNull(message = "사용자 비밀번호는 반드시 입력해야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,15}$",
+        message = "비밀번호는 8~15자이며, 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.")
+    String password,
+
+    @NotNull(message = "소속된 업체명을 알고있는지 반드시 입력해야 합니다. TRUE | FALSE")
+    boolean hasCompanyId,
+
+    UUID organization,
+
+    @NotNull(message = "사용자 슬랙 이메일주소는 반드시 입력해야 합니다.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+    ,message = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+    String slackEmail,
+
+    @Size(max = 50)
+    String summary
+    ) {
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/presentation/dto/request/FormLoginRequestDto.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/dto/request/FormLoginRequestDto.java
@@ -1,0 +1,8 @@
+package com.gbg.userservice.presentation.dto.request;
+
+public record FormLoginRequestDto(
+    String username,
+    String password
+) {
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/CreateUserResponseDto.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/CreateUserResponseDto.java
@@ -1,0 +1,16 @@
+package com.gbg.userservice.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CreateUserResponseDto(
+
+    UUID userId
+
+) {
+
+    public static CreateUserResponseDto of(UUID uuid) {
+        return new CreateUserResponseDto(uuid);
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/UserResponseDto.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/UserResponseDto.java
@@ -1,0 +1,27 @@
+package com.gbg.userservice.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.gbg.userservice.domain.entity.UserRole;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserResponseDto {
+
+    UserDto user;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class UserDto {
+
+        String username;
+        String nickname;
+        String slackEmail;
+        UUID organization;
+        UserRole role;
+    }
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,10 +1,12 @@
-server:
-  port: 0 # config에서 덮어쓰기 전까지는 0 (랜덤) 또는 로컬값
-
 spring:
   application:
     name: user-service
   profiles:
     active: dev
+
   config:
     import: "configserver:http://localhost:8888"
+
+  cloud:
+    config:
+      name: user-service

--- a/user-service/src/test/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImplTest.java
+++ b/user-service/src/test/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImplTest.java
@@ -17,7 +17,7 @@ class UserRepositoryImplTest {
     @Test
     void createBaseEntityTest() {
 
-        User user = User.of("test", "test", "test", "test", "test", UserRole.MASTER);
+        User user = User.of("test", "test", "test", "test", "test");
 
         User save =  userRepository.save(user);
 


### PR DESCRIPTION
## 📝 PR 제목
> 사용자 회원가입 ,로그인 기능 구현 

---

### 🔍 관련 이슈
- Close #25 #26 #27 

---

### ✨ 작업 내용 요약
> 사용자 회원 가입 가능하며, 로그인시 JWT 토큰 발행 (60분)
> 유저 서비스 스프링 시큐리티 적용 (사용자 전체조회시 토큰 가지고 있는 유저만 조회가능)
> 추후 관리자만 조회가능하게 변경할 예정 

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> user-service yml 파일 일부분 수정, 
> config-service -> user-service-dev.yml 파일 수정 

---

### ✅ 테스트 및 검증 내용
> 회원가입은 swagger에서 가능하나 swagger는 명세로만 봐주시고 테스트는 
> 기존에 진행하던 방식으로 포스트맨이나, talend 사용해서 테스트 진행해주세요. 
> 테스트 해본 결과 정상적으로 작동됩니다



- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
<img width="1320" height="668" alt="스크린샷 2025-11-06 오전 3 57 19" src="https://github.com/user-attachments/assets/89dd0183-6d5c-4480-8245-7321f9db22cc" />

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.