### PR TITLE
Feat/게이트웨이 인증 기반 허브 서비스 구현

### DIFF
--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -30,14 +30,14 @@ ext {
 }
 
 dependencies {
-    implementation 'com.github.GBG-Gaboja-Go:gabojago-common:1.0.9'
+    implementation 'com.github.GBG-Gaboja-Go:gabojago-common:1.1.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/hub-service/src/main/java/com/gbg/hubservice/application/service/impl/HubServiceImpl.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/application/service/impl/HubServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gbg.hubservice.application.service.impl;
 
 import com.gabojago.exception.AppException;
+import com.gabojago.util.PageableUtils;
 import com.gbg.hubservice.application.service.HubService;
 import com.gbg.hubservice.application.service.exception.HubErrorCode;
 import com.gbg.hubservice.domain.entity.Hub;
@@ -49,6 +50,7 @@ public class HubServiceImpl implements HubService {
 
     @Override
     public Page<Hub> getPage(Pageable pageable) {
+        pageable = PageableUtils.normalize(pageable);
         return hubRepository.findAll(pageable);
     }
 

--- a/hub-service/src/main/java/com/gbg/hubservice/application/service/impl/HubServiceImpl.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/application/service/impl/HubServiceImpl.java
@@ -4,7 +4,7 @@ import com.gabojago.exception.AppException;
 import com.gbg.hubservice.application.service.HubService;
 import com.gbg.hubservice.application.service.exception.HubErrorCode;
 import com.gbg.hubservice.domain.entity.Hub;
-import com.gbg.hubservice.infrastructure.repository.HubJpaRepository;
+import com.gbg.hubservice.domain.repository.HubRepository;
 import com.gbg.hubservice.presentation.dto.request.CreateHubRequestDto;
 import com.gbg.hubservice.presentation.dto.request.UpdateHubRequestDto;
 import java.util.UUID;
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HubServiceImpl implements HubService {
 
-    private final HubJpaRepository hubRepository;
+    private final HubRepository hubRepository;
 
     @Override
     @Transactional
@@ -38,8 +38,7 @@ public class HubServiceImpl implements HubService {
             .userId(userId)
             .build();
 
-        Hub savedHub = hubRepository.save(hub);
-        return savedHub.getId();
+        return hubRepository.save(hub).getId();
     }
 
     @Override

--- a/hub-service/src/main/java/com/gbg/hubservice/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/domain/repository/HubRepository.java
@@ -1,0 +1,19 @@
+package com.gbg.hubservice.domain.repository;
+
+import com.gbg.hubservice.domain.entity.Hub;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface HubRepository {
+
+    boolean existsByName(String name);
+
+    Optional<Hub> findById(UUID id);
+
+    Page<Hub> findAll(Pageable pageable);
+
+    Hub save(Hub hub);
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/CustomAuditAware.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/CustomAuditAware.java
@@ -1,0 +1,38 @@
+package com.gbg.hubservice.infrastructure.config;
+
+import com.gbg.hubservice.infrastructure.config.auth.CustomUser;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class CustomAuditAware implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+
+        Authentication authentication
+            = SecurityContextHolder.getContext().getAuthentication();
+        System.out.println("[AuditorAware] : authentication : " + authentication);
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            System.out.println("[AuditorAware] 인증 정보가 없거나 인증되지 않은 상태입니다.");
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        System.out.println("[AuditorAware] : principal : " + principal);
+
+        if (principal instanceof CustomUser user) {
+            System.out.println("[AuditorAware] 로그인 사용자 ID : " + user.getId());
+            return Optional.ofNullable(user.getId());
+        }
+
+        System.out.println(
+            "[AuditorAware] Principal이 CustomUser 타입이 아닙니다. 현재 타입 : " + (principal != null
+                ? principal.getClass().getName() : "null"));
+        return Optional.empty();
+    }
+
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/JpaConfig.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/JpaConfig.java
@@ -1,10 +1,17 @@
 package com.gbg.hubservice.infrastructure.config;
 
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
 
+    @Bean
+    public AuditorAware<UUID> auditorProvider() {
+        return new CustomAuditAware();
+    }
 }

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.gbg.hubservice.infrastructure.config;
+
+import com.gbg.hubservice.infrastructure.config.filter.HeaderAuthFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final HeaderAuthFilter headerAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+        DefaultAuthenticationEventPublisher publisher) throws Exception {
+
+        http
+            //  JWT 기반 인증 사용 → CSRF 비활성화
+            .csrf(AbstractHttpConfigurer::disable)
+
+            //  세션 미사용 (Stateless)
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // 권한 규칙 설정
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/v1/hubs/**").hasRole("MASTER")
+                .requestMatchers(HttpMethod.PUT, "/v1/hubs/**").hasRole("MASTER")
+                .requestMatchers(HttpMethod.DELETE, "/v1/hubs/**").hasRole("MASTER")
+
+                // 그 외 요청은 인증만 되면 접근 가능
+                .anyRequest().authenticated()
+            )
+
+            //  게이트웨이에서 전달한 헤더(X-Auth-Id, X-Auth-Role)로 인증 복원
+            .addFilterBefore(headerAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -36,8 +38,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/v1/hubs/**").hasRole("MASTER")
                 .requestMatchers(HttpMethod.PUT, "/v1/hubs/**").hasRole("MASTER")
                 .requestMatchers(HttpMethod.DELETE, "/v1/hubs/**").hasRole("MASTER")
-
-                // 그 외 요청은 인증만 되면 접근 가능
                 .anyRequest().authenticated()
             )
 

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/auth/CustomUser.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/auth/CustomUser.java
@@ -1,0 +1,52 @@
+package com.gbg.hubservice.infrastructure.config.auth;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUser implements UserDetails {
+
+    private final UUID userId;
+    private final List<? extends GrantedAuthority> authorities;
+
+    @Override
+    public String getUsername() {
+        return userId.toString();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/auth/CustomUser.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/auth/CustomUser.java
@@ -12,12 +12,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 @RequiredArgsConstructor
 public class CustomUser implements UserDetails {
 
-    private final UUID userId;
+    private final UUID Id;
     private final List<? extends GrantedAuthority> authorities;
 
     @Override
     public String getUsername() {
-        return userId.toString();
+        return Id.toString();
     }
 
     @Override

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/filter/HeaderAuthFilter.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/filter/HeaderAuthFilter.java
@@ -1,0 +1,49 @@
+package com.gbg.hubservice.infrastructure.config.filter;
+
+import com.gbg.hubservice.infrastructure.config.auth.CustomUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class HeaderAuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain chain) throws ServletException, IOException {
+
+        String idHeader = request.getHeader("X-Auth-Id");
+        String roleHeader = request.getHeader("X-Auth-Role");
+
+        if (StringUtils.hasText(idHeader) && StringUtils.hasText(roleHeader)) {
+            try {
+                UUID userId = UUID.fromString(idHeader.trim());
+
+                String role = roleHeader.trim();
+                if (!role.startsWith("ROLE_")) {
+                    role = "ROLE_" + role;
+                }
+
+                var authorities = List.of(new SimpleGrantedAuthority(role));
+                var principal = new CustomUser(userId, authorities);
+                var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (IllegalArgumentException ignore) {
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/repository/HubJpaRepository.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/repository/HubJpaRepository.java
@@ -1,13 +1,10 @@
 package com.gbg.hubservice.infrastructure.repository;
 
 import com.gbg.hubservice.domain.entity.Hub;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
 
     boolean existsByName(String name);
-
-    Optional<Hub> findById(UUID id);
 }

--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/repository/HubRepositoryImpl.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/repository/HubRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.gbg.hubservice.infrastructure.repository;
+
+import com.gbg.hubservice.domain.entity.Hub;
+import com.gbg.hubservice.domain.repository.HubRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRepositoryImpl implements HubRepository {
+
+    private final HubJpaRepository jpa;
+
+    @Override
+    public boolean existsByName(String name) {
+        return jpa.existsByName(name);
+    }
+
+    @Override
+    public Optional<Hub> findById(UUID id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Page<Hub> findAll(Pageable pageable) {
+        return jpa.findAll(pageable);
+    }
+
+    @Override
+    public Hub save(Hub hub) {
+        return jpa.save(hub);
+    }
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/presentation/advice/CustomExceptionHandler.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/presentation/advice/CustomExceptionHandler.java
@@ -1,9 +1,32 @@
 package com.gbg.hubservice.presentation.advice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gabojago.exception.ErrorResponse;
 import com.gabojago.exception.GlobalExceptionHandler;
+import com.gbg.hubservice.application.service.exception.HubErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class CustomExceptionHandler extends GlobalExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<Object> handleAuthorizeDeniedException(AuthorizationDeniedException ex) {
+        ErrorResponse errorResponse = ErrorResponse.from(HubErrorCode.HUB_PERMISSION_DENIED);
+
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(errorResponse);
+
+    }
 
 }

--- a/hub-service/src/main/java/com/gbg/hubservice/presentation/advice/CustomExceptionHandler.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/presentation/advice/CustomExceptionHandler.java
@@ -1,0 +1,9 @@
+package com.gbg.hubservice.presentation.advice;
+
+import com.gabojago.exception.GlobalExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionHandler extends GlobalExceptionHandler {
+
+}

--- a/hub-service/src/main/java/com/gbg/hubservice/presentation/controller/HubController.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/presentation/controller/HubController.java
@@ -43,7 +43,7 @@ public class HubController {
         @Valid @RequestBody CreateHubRequestDto requestDto,
         @AuthenticationPrincipal CustomUser user
     ) {
-        UUID createdId = hubService.create(requestDto, user.getUserId());
+        UUID createdId = hubService.create(requestDto, user.getId());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(BaseResponseDto.success("허브 생성 성공", CreateHubResponseDto.of(createdId),
                 HttpStatus.CREATED));
@@ -87,7 +87,7 @@ public class HubController {
         @Parameter(description = "허브 UUID") @PathVariable UUID hubId,
         @AuthenticationPrincipal CustomUser user
     ) {
-        hubService.delete(hubId, user.getUserId());
+        hubService.delete(hubId, user.getId());
         return ResponseEntity.ok(BaseResponseDto.success("허브 삭제 성공", HttpStatus.OK));
     }
 }

--- a/hub-service/src/main/java/com/gbg/hubservice/presentation/controller/HubController.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/presentation/controller/HubController.java
@@ -3,6 +3,7 @@ package com.gbg.hubservice.presentation.controller;
 import com.gabojago.dto.BaseResponseDto;
 import com.gbg.hubservice.application.service.HubService;
 import com.gbg.hubservice.domain.entity.Hub;
+import com.gbg.hubservice.infrastructure.config.auth.CustomUser;
 import com.gbg.hubservice.presentation.dto.request.CreateHubRequestDto;
 import com.gbg.hubservice.presentation.dto.request.UpdateHubRequestDto;
 import com.gbg.hubservice.presentation.dto.response.CreateHubResponseDto;
@@ -17,13 +18,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,11 +39,13 @@ public class HubController {
     @Operation(summary = "허브 생성 API", description = "마스터관리자만 허브를 생성할 수 있습니다.")
     public ResponseEntity<BaseResponseDto<CreateHubResponseDto>> createHub(
         @Valid @RequestBody CreateHubRequestDto requestDto,
-        @RequestHeader("X-Auth-Id") UUID userId) {
+        Authentication authentication
+    ) {
+        UUID userId = ((CustomUser) authentication.getPrincipal()).getUserId();
         UUID createdId = hubService.create(requestDto, userId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(
-            BaseResponseDto.success("허브 생성 성공", CreateHubResponseDto.of(createdId),
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(BaseResponseDto.success("허브 생성 성공", CreateHubResponseDto.of(createdId),
                 HttpStatus.CREATED));
     }
 
@@ -57,12 +60,12 @@ public class HubController {
     @GetMapping("/{hubId}")
     @Operation(summary = "허브 상세 조회 API", description = "허브 ID로 상세 정보를 조회합니다.")
     public ResponseEntity<BaseResponseDto<GetHubResponseDto>> getHub(
-        @Parameter(description = "허브 UUID") @PathVariable UUID hubId) {
+        @Parameter(description = "허브 UUID") @PathVariable UUID hubId
+    ) {
         Hub hub = hubService.getById(hubId);
-
-        GetHubResponseDto responseDto = GetHubResponseDto.of(hub.getId(), hub.getName(),
-            hub.getAddress(), hub.getLatitude(), hub.getLongitude());
-
+        GetHubResponseDto responseDto = GetHubResponseDto.of(
+            hub.getId(), hub.getName(), hub.getAddress(), hub.getLatitude(), hub.getLongitude()
+        );
         return ResponseEntity.ok(BaseResponseDto.success("허브 조회 성공", responseDto, HttpStatus.OK));
     }
 
@@ -70,19 +73,20 @@ public class HubController {
     @Operation(summary = "허브 정보 수정 API", description = "허브 이름/주소/위도/경도를 수정합니다.")
     public ResponseEntity<BaseResponseDto<Void>> updateHub(
         @Parameter(description = "허브 UUID") @PathVariable UUID hubId,
-        @Valid @RequestBody UpdateHubRequestDto requestDto) {
+        @Valid @RequestBody UpdateHubRequestDto requestDto
+    ) {
         hubService.update(hubId, requestDto);
         return ResponseEntity.ok(BaseResponseDto.success("허브 수정 성공", HttpStatus.OK));
     }
 
     @DeleteMapping("/{hubId}")
-    @Operation(summary = "허브 삭제 API", description = "허브를 삭제합니다.")
+    @Operation(summary = "허브 삭제 API", description = "허브를 삭제합니다. (소프트 삭제)")
     public ResponseEntity<BaseResponseDto<Void>> deleteHub(
         @Parameter(description = "허브 UUID") @PathVariable UUID hubId,
-        @RequestHeader("X-Auth-Id") UUID userId) {
+        Authentication authentication
+    ) {
+        UUID userId = ((CustomUser) authentication.getPrincipal()).getUserId();
         hubService.delete(hubId, userId);
         return ResponseEntity.ok(BaseResponseDto.success("허브 삭제 성공", HttpStatus.OK));
     }
-
-
 }


### PR DESCRIPTION
## 📝 PR 제목
>게이트웨이 인증 기반 허브 서비스 구현

---

### 🔍 관련 이슈
- Close #66 

---

### ✨ 작업 내용 요약

- 게이트웨이에서 전달되는 헤더(X-Auth-Id, X-Auth-Role) 기반 인증 로직 구현
- @EnableMethodSecurity 활성화 및 컨트롤러별 역할 권한 부여 (@PreAuthorize)
- CustomExceptionHandler 추가로 권한 거부(403) 예외 처리 통일
- PageableUtils 적용으로 페이지 정렬·조회 제한 기능 구현
- Hub 도메인 포트/어댑터 분리 구조 반영 및 코드 리팩토링 

---

### ⚙️ 주요 변경 사항

- SecurityConfig: 헤더 인증 필터 추가 및 권한 설정
- HeaderAuthFilter: 게이트웨이 헤더 기반 인증 로직 구현
- HubController: @PreAuthorize 및 @AuthenticationPrincipal 적용
- CustomExceptionHandler: 권한 예외 처리 추가

---

### ✅ 테스트 및 검증 내용
- [x] 로컬 환경 Postman으로 API 인증·인가 확인
- [x] MASTER 권한만 허브 생성/수정/삭제 가능 확인

---

### 📸 스크린샷 
**허브 생성  POST v1/hubs**
<img width="1428" height="698" alt="image" src="https://github.com/user-attachments/assets/00fb2134-68fc-4370-86d2-a990befaf521" />

**허브 단일 조회 GET v1/hubs/{hubId}**
<img width="1441" height="565" alt="image" src="https://github.com/user-attachments/assets/94e8942a-d06d-474e-a763-a0c37faf16af" />


**허브 목록 조회 GET v1/hubs**
<img width="1446" height="879" alt="image" src="https://github.com/user-attachments/assets/80b4239c-4be2-44ca-935a-02faa18a1258" />

**허브 수정 PUT v1/hubs/{hubId}**
<img width="1446" height="594" alt="image" src="https://github.com/user-attachments/assets/e4c77885-71a1-4248-9ebc-6e06c234e1c1" />
수정 후 조회 
<img width="1438" height="575" alt="image" src="https://github.com/user-attachments/assets/db75bcd5-b36b-4278-8d33-4bc777482db9" />

**허브 삭제 DELETE v1/hubs/{hubId}**
<img width="1463" height="387" alt="image" src="https://github.com/user-attachments/assets/660b7251-fb9c-4296-a237-2dd6d4360687" />

---

### 💬 기타 참고 사항
> 게이트웨이 인증 필터 기반으로 구현했습니다. 