### PR TITLE
Feat/slack create 78

### DIFF
--- a/slack-service/src/main/java/com/gbg/slackservice/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/application/service/SlackService.java
@@ -8,4 +8,6 @@ public interface SlackService {
 
 
     void sendVerifySuccessMessage(String channelId, String text);
+
+    void sendDm(String email, String message);
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/domain/entity/Slack.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/domain/entity/Slack.java
@@ -1,6 +1,7 @@
 package com.gbg.slackservice.domain.entity;
 
 import com.gabojago.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +22,27 @@ public class Slack extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(nullable = false)
+    private String receiverId;
 
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean success = false;
+
+    public void updateSuccess(boolean success) {
+        this.success = success;
+    }
+
+    private Slack(String receiverId, String content, boolean success) {
+        this.receiverId = receiverId;
+        this.content = content;
+        this.success = success;
+    }
+
+    public static Slack of(String receiverId, String content) {
+        return new Slack(receiverId, content, false);
+    }
 
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/domain/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/domain/repository/SlackRepository.java
@@ -1,5 +1,8 @@
 package com.gbg.slackservice.domain.repository;
 
+import com.gbg.slackservice.domain.entity.Slack;
+
 public interface SlackRepository {
 
+    void save(Slack slack);
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/auth/CustomAccessDeniedHandler.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/auth/CustomAccessDeniedHandler.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gabojago.exception.AppException;
 import com.gabojago.exception.ErrorResponse;
 
-import com.gbg.slackservice.infrastructure.exception.UserErrorCode;
+import com.gbg.slackservice.infrastructure.exception.SlackError;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,7 +33,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         AccessDeniedException accessDeniedException
     ) throws IOException, ServletException {
 
-        AppException exception = new AppException(UserErrorCode.USER_FORBIDDEN);
+        AppException exception = new AppException(SlackError.USER_FORBIDDEN);
 
         response.setStatus(exception.getErrorCode().getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/auth/CustomAuthenticationEntryPoint.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/auth/CustomAuthenticationEntryPoint.java
@@ -3,7 +3,7 @@ package com.gbg.slackservice.infrastructure.config.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gabojago.exception.ErrorResponse;
 
-import com.gbg.slackservice.infrastructure.exception.UserErrorCode;
+import com.gbg.slackservice.infrastructure.exception.SlackError;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,7 +32,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        ErrorResponse errorResponse = ErrorResponse.from(UserErrorCode.USER_UNAUTHORIZED);
+        ErrorResponse errorResponse = ErrorResponse.from(SlackError.USER_UNAUTHORIZED);
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/exception/SlackError.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/exception/SlackError.java
@@ -5,18 +5,19 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum UserErrorCode implements ErrorCode {
+public enum SlackError implements ErrorCode {
 
     USER_UNAUTHORIZED("USER000", "사용자 인증에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("USER001", "해당 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER_FORBIDDEN("USER004", "사용자 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    SLACK_USER_NOT_FOUND("SLACK000", "슬랙 채널에 등록되지 않은 사용자 입니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String code;
     private final String message;
     private final HttpStatus status;
 
-    UserErrorCode(String code, String message, HttpStatus status) {
+    SlackError(String code, String message, HttpStatus status) {
         this.code = code;
         this.message = message;
         this.status = status;

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/repository/SlackRepositoryImpl.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/repository/SlackRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.gbg.slackservice.infrastructure.repository;
 
+import com.gbg.slackservice.domain.entity.Slack;
 import com.gbg.slackservice.domain.repository.SlackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,9 @@ public class SlackRepositoryImpl implements SlackRepository {
     private final SlackJpaRepository slackJpaRepository;
 
 
+    @Override
+    public void save(Slack slack) {
 
-
+        slackJpaRepository.save(slack);
+    }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
@@ -71,7 +71,7 @@ public class SlackController {
         return BaseResponseDto.success(
             "Slack DM 전송 완료",
             null,
-            HttpStatus.NO_CONTENT
+            HttpStatus.OK
         );
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
@@ -3,6 +3,7 @@ package com.gbg.slackservice.presentation.controller;
 import com.gabojago.dto.BaseResponseDto;
 import com.gbg.slackservice.application.service.SlackService;
 import com.gbg.slackservice.infrastructure.config.auth.CustomUser;
+import com.gbg.slackservice.presentation.dto.request.SlackSendDmRequest;
 import com.gbg.slackservice.presentation.dto.request.SlackVerifyRequest;
 import com.gbg.slackservice.presentation.dto.request.SlackVerifySuccessRequest;
 import com.gbg.slackservice.presentation.dto.response.SlackVerifyResponse;
@@ -57,6 +58,20 @@ public class SlackController {
             "메시지 전송 완료",
             null,
             HttpStatus.OK
+        );
+    }
+
+    @PostMapping("/send-dm")
+    public BaseResponseDto<String> sendDm(
+        @RequestBody SlackSendDmRequest req
+    ) {
+
+        slackService.sendDm(req.email(), req.message());
+
+        return BaseResponseDto.success(
+            "Slack DM 전송 완료",
+            null,
+            HttpStatus.NO_CONTENT
         );
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/request/SlackSendDmRequest.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/request/SlackSendDmRequest.java
@@ -1,0 +1,8 @@
+package com.gbg.slackservice.presentation.dto.request;
+
+public record SlackSendDmRequest(
+    String email,
+    String message
+) {
+
+}

--- a/slack-service/src/test/java/com/gbg/slackservice/application/service/impl/SlackServiceImplTest.java
+++ b/slack-service/src/test/java/com/gbg/slackservice/application/service/impl/SlackServiceImplTest.java
@@ -1,0 +1,44 @@
+package com.gbg.slackservice.application.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gbg.slackservice.presentation.dto.request.SlackSendDmRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class SlackServiceImplTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("이메일 기반 Slack DM 전송 성공 테스트 ")
+    void sendDm() throws Exception {
+        // given
+        SlackSendDmRequest req = new SlackSendDmRequest(
+            "yuch0102@gmail.com",
+            "디엠 전송 테스트"
+        );
+
+        //when & then
+        mockMvc.perform(post("/v1/slacks/send-dm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isOk());
+    }
+}

--- a/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
@@ -23,4 +23,6 @@ public interface UserService {
     UUID adminDetailUpdate(UUID loginId, UUID userId, AdminUpdateRequestDto req);
 
     UserStatus getUserStatus(UUID userId);
+
+    UserResponseDto getUser(UUID userId);
 }

--- a/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
@@ -43,7 +43,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public UserResponseDto userDetail(UUID id) {
-        User findUser = getUser(id);
+        User findUser = findUser(id);
 
         return UserResponseDto.builder()
             .user(UserResponseDto.UserDto.builder()
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UUID userDetailUpdate(UserUpdateRequestDto req, UUID id) {
-        User findUser = getUser(id);
+        User findUser = findUser(id);
 
         if (req.nickname() != null) {
             findUser.changeNickname(req.nickname());
@@ -82,7 +82,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void userDelete(UUID loginId ,UUID userId) {
-        User findUser = getUser(userId);
+        User findUser = findUser(userId);
 
         findUser.delete(loginId);
     }
@@ -118,13 +118,32 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public UserResponseDto getUser(UUID userId) {
+        User user = findUser(userId);
+
+        return UserResponseDto.builder()
+            .user(UserResponseDto.UserDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .slackEmail(user.getSlackEmail())
+                .organization(user.getOrganization())
+                .summary(user.getSummary())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .build())
+            .build();
+    }
+
+    @Override
     public UserStatus getUserStatus(UUID userId) {
-        User user = getUser(userId);
+        User user = findUser(userId);
 
         return user.getStatus();
     }
 
-    private User getUser(UUID userId) {
+
+    private User findUser(UUID userId) {
 
         User user = userRepository.findById(userId).orElseThrow(
             () -> new AppException(UserErrorCode.USER_NOT_FOUND)

--- a/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
@@ -77,6 +77,20 @@ public class UserController {
                 HttpStatus.OK));
     }
 
+    @GetMapping("/internal/{userId}")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<BaseResponseDto<UserResponseDto>> getUser(
+        @PathVariable("userId") UUID userId
+    ) {
+
+        UserResponseDto user = userService.getUser(userId);
+        return ResponseEntity.ok(BaseResponseDto.success(
+            "사용자 정보 조회 완료",
+            user,
+            HttpStatus.OK
+        ));
+    }
+
     @PatchMapping("/my-page")
     public ResponseEntity<BaseResponseDto<UUID>> userDetailUpdate(
         @RequestBody UserUpdateRequestDto req,
@@ -123,7 +137,7 @@ public class UserController {
             .status(HttpStatus.NO_CONTENT)
             .body(BaseResponseDto.success(
                 "사용자 삭제가 정상적으로 처리되었습니다.",
-                    HttpStatus.NO_CONTENT
+                HttpStatus.NO_CONTENT
             ));
     }
 


### PR DESCRIPTION
## 📝 PR 제목
> 슬랙 개인 DM 메시지 전송 기능 구현 

---

### 🔍 관련 이슈
- Close #78 

---

### ✨ 작업 내용 요약
> 서버에서 개인에게 슬랙 DM 보낼 수 있음. 
> 내부 에서 유저 조회 API 생성 

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.