### PR TITLE
Feat/slack create 82

### DIFF
--- a/config-service/src/main/resources/config-repository/slack-service-dev.yml
+++ b/config-service/src/main/resources/config-repository/slack-service-dev.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 
 
 
-
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -42,6 +41,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testImplementation 'io.projectreactor:reactor-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/slack-service/src/main/java/com/gbg/slackservice/SlackServiceApplication.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/SlackServiceApplication.java
@@ -3,9 +3,11 @@ package com.gbg.slackservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class SlackServiceApplication {
 
     public static void main(String[] args) {

--- a/slack-service/src/main/java/com/gbg/slackservice/application/service/SlackService.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/application/service/SlackService.java
@@ -1,6 +1,8 @@
 package com.gbg.slackservice.application.service;
 
+import com.gbg.slackservice.presentation.dto.response.SlackResponseDto;
 import com.gbg.slackservice.presentation.dto.response.SlackVerifyResponse;
+import java.util.List;
 
 public interface SlackService {
 
@@ -10,4 +12,6 @@ public interface SlackService {
     void sendVerifySuccessMessage(String channelId, String text);
 
     void sendDm(String email, String message);
+
+    SlackResponseDto slackLogs();
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/application/service/impl/SlackServiceImpl.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/application/service/impl/SlackServiceImpl.java
@@ -6,14 +6,18 @@ import com.gbg.slackservice.application.service.SlackService;
 import com.gbg.slackservice.domain.entity.Slack;
 import com.gbg.slackservice.domain.repository.SlackRepository;
 import com.gbg.slackservice.infrastructure.exception.SlackError;
+import com.gbg.slackservice.presentation.dto.response.SlackResponseDto;
 import com.gbg.slackservice.presentation.dto.response.SlackVerifyResponse;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
@@ -103,5 +107,24 @@ public class SlackServiceImpl implements SlackService {
             slackRepository.save(slack);
         }
 
+    }
+
+    @Override
+    public SlackResponseDto slackLogs() {
+
+        List<Slack> slacks = slackRepository.findAll();
+        List<SlackResponseDto.SlackDto> slackDtos = slacks.stream()
+            .map(s -> SlackResponseDto.SlackDto.builder()
+                .id(s.getId())
+                .receiverId(s.getReceiverId())
+                .content(s.getContent())
+                .success(s.isSuccess())
+                .createdBy(s.getCreatedBy())
+                .build())
+            .toList();
+
+        return SlackResponseDto.builder()
+            .slacks(slackDtos)
+            .build();
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/domain/entity/Slack.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/domain/entity/Slack.java
@@ -22,10 +22,10 @@ public class Slack extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 512)
     private String receiverId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/slack-service/src/main/java/com/gbg/slackservice/domain/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/domain/repository/SlackRepository.java
@@ -1,8 +1,11 @@
 package com.gbg.slackservice.domain.repository;
 
 import com.gbg.slackservice.domain.entity.Slack;
+import java.util.List;
 
 public interface SlackRepository {
 
     void save(Slack slack);
+
+    List<Slack> findAll();
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/client/UserClient.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/client/UserClient.java
@@ -1,0 +1,17 @@
+package com.gbg.slackservice.infrastructure.client;
+
+import com.gbg.slackservice.presentation.dto.response.UserResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+    @GetMapping("/v1/users/internal/email/{email}")
+    UserResponseDto getUserByEmail(
+        @PathVariable("email") String email,
+        @RequestHeader("Authorization") String token);
+
+}

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/SecurityConfig.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.gbg.slackservice.infrastructure.config;
 
 import com.gbg.slackservice.infrastructure.config.auth.CustomAccessDeniedHandler;
+import com.gbg.slackservice.infrastructure.config.auth.CustomAuthenticationEntryPoint;
 import com.gbg.slackservice.infrastructure.config.filter.HeaderAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 
     private final HeaderAuthFilter headerAuthFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
@@ -35,8 +37,8 @@ public class SecurityConfig {
             )
 
             .exceptionHandling(ex -> ex
-                .accessDeniedHandler(customAccessDeniedHandler))
-
+                .accessDeniedHandler(customAccessDeniedHandler)
+                .authenticationEntryPoint(customAuthenticationEntryPoint))
 
             .addFilterBefore(headerAuthFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/slack-service/src/main/java/com/gbg/slackservice/infrastructure/repository/SlackRepositoryImpl.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/infrastructure/repository/SlackRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.gbg.slackservice.infrastructure.repository;
 
 import com.gbg.slackservice.domain.entity.Slack;
 import com.gbg.slackservice.domain.repository.SlackRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +17,11 @@ public class SlackRepositoryImpl implements SlackRepository {
     public void save(Slack slack) {
 
         slackJpaRepository.save(slack);
+    }
+
+    @Override
+    public List<Slack> findAll() {
+
+        return slackJpaRepository.findAll();
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/advice/CustomExceptionHandler.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/advice/CustomExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.gbg.slackservice.presentation.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gabojago.exception.ErrorResponse;
+import com.gabojago.exception.GlobalExceptionHandler;
+import com.gbg.slackservice.infrastructure.exception.SlackError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class CustomExceptionHandler extends GlobalExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<Object> handleAuthorizeDeniedException(AuthorizationDeniedException ex) {
+        ErrorResponse errorResponse = ErrorResponse.from(SlackError.USER_FORBIDDEN);
+
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(errorResponse);
+    }
+
+}

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/controller/SlackController.java
@@ -1,15 +1,19 @@
 package com.gbg.slackservice.presentation.controller;
 
 import com.gabojago.dto.BaseResponseDto;
+import com.gabojago.exception.AppException;
 import com.gbg.slackservice.application.service.SlackService;
 import com.gbg.slackservice.infrastructure.config.auth.CustomUser;
 import com.gbg.slackservice.presentation.dto.request.SlackSendDmRequest;
 import com.gbg.slackservice.presentation.dto.request.SlackVerifyRequest;
 import com.gbg.slackservice.presentation.dto.request.SlackVerifySuccessRequest;
+import com.gbg.slackservice.presentation.dto.response.SlackResponseDto;
 import com.gbg.slackservice.presentation.dto.response.SlackVerifyResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -65,7 +69,6 @@ public class SlackController {
     public BaseResponseDto<String> sendDm(
         @RequestBody SlackSendDmRequest req
     ) {
-
         slackService.sendDm(req.email(), req.message());
 
         return BaseResponseDto.success(
@@ -73,5 +76,18 @@ public class SlackController {
             null,
             HttpStatus.OK
         );
+    }
+
+    @GetMapping("/logs")
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ResponseEntity<BaseResponseDto<SlackResponseDto>> slackLogs() {
+
+        SlackResponseDto slackResponseDto = slackService.slackLogs();
+
+        return ResponseEntity.ok(BaseResponseDto.success(
+            "슬랙 로그 조회 성공",
+            slackResponseDto,
+            HttpStatus.OK
+        ));
     }
 }

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/response/SlackResponseDto.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/response/SlackResponseDto.java
@@ -1,0 +1,23 @@
+package com.gbg.slackservice.presentation.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SlackResponseDto {
+
+    List<SlackDto> slacks;
+
+    @Getter
+    @Builder
+    public static class SlackDto {
+        UUID id;
+        String receiverId;
+        String content;
+        boolean success;
+        UUID createdBy;
+    }
+}

--- a/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/response/UserResponseDto.java
+++ b/slack-service/src/main/java/com/gbg/slackservice/presentation/dto/response/UserResponseDto.java
@@ -1,0 +1,21 @@
+package com.gbg.slackservice.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDto {
+
+    UUID id;
+    String username;
+    String nickname;
+    String slackEmail;
+    boolean slackVerified;
+    UUID organization;
+    String summary;
+    String role;
+    String status;
+
+}

--- a/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/UserService.java
@@ -1,5 +1,6 @@
 package com.gbg.userservice.application.service;
 
+import com.gbg.userservice.domain.entity.User;
 import com.gbg.userservice.domain.entity.UserRole;
 import com.gbg.userservice.domain.entity.UserStatus;
 import com.gbg.userservice.infrastructure.config.auth.CustomUser;
@@ -24,5 +25,7 @@ public interface UserService {
 
     UserStatus getUserStatus(UUID userId);
 
-    UserResponseDto getUser(UUID userId);
+    User getUser(UUID userId);
+
+    User getUserByEmail(String email);
 }

--- a/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/application/service/impl/UserServiceImpl.java
@@ -118,21 +118,17 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserResponseDto getUser(UUID userId) {
-        User user = findUser(userId);
+    public User getUser(UUID userId) {
 
-        return UserResponseDto.builder()
-            .user(UserResponseDto.UserDto.builder()
-                .id(user.getId())
-                .username(user.getUsername())
-                .nickname(user.getNickname())
-                .slackEmail(user.getSlackEmail())
-                .organization(user.getOrganization())
-                .summary(user.getSummary())
-                .role(user.getRole())
-                .status(user.getStatus())
-                .build())
-            .build();
+        return findUser(userId);
+    }
+
+    @Override
+    public User getUserByEmail(String email) {
+
+        return userRepository.findBySlackEmail(email).orElseThrow(
+            () -> new AppException(UserErrorCode.USER_NOT_FOUND)
+        );
     }
 
     @Override

--- a/user-service/src/main/java/com/gbg/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/gbg/userservice/domain/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository {
     Optional<User> findByUserName(String username);
 
     Optional<User> findById(UUID userId);
+
+    Optional<User> findBySlackEmail(String email);
 }

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserJpaRepository.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserJpaRepository.java
@@ -13,4 +13,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findById(UUID userId);
+
+    Optional<User> findBySlackEmail(String slackEmail);
 }

--- a/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/gbg/userservice/infrastructure/repository/UserRepositoryImpl.java
@@ -43,4 +43,10 @@ public class UserRepositoryImpl implements UserRepository {
 
         return userJpaRepository.findById(userId);
     }
+
+    @Override
+    public Optional<User> findBySlackEmail(String email) {
+
+        return userJpaRepository.findBySlackEmail(email);
+    }
 }

--- a/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
@@ -95,16 +95,11 @@ public class UserController {
 
     @GetMapping("/internal/email/{email}")
     @PreAuthorize("hasRole('MASTER')")
-    public ResponseEntity<BaseResponseDto<User>> getUserByEmail(
+    public User getUserByEmail(
         @PathVariable("email") String email
     ) {
 
-        User user = userService.getUserByEmail(email);
-        return ResponseEntity.ok(BaseResponseDto.success(
-            "유저 객체 반환 완료",
-            user,
-            HttpStatus.OK
-        ));
+        return userService.getUserByEmail(email);
     }
 
     @PatchMapping("/my-page")

--- a/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -77,29 +76,6 @@ public class UserController {
                 "조회 성공",
                 user,
                 HttpStatus.OK));
-    }
-
-    @GetMapping("/internal/userId/{userId}")
-    @PreAuthorize("hasRole('MASTER')")
-    public ResponseEntity<BaseResponseDto<User>> getUser(
-        @PathVariable("userId") UUID userId
-    ) {
-
-        User user = userService.getUser(userId);
-        return ResponseEntity.ok(BaseResponseDto.success(
-            "사용자 정보 조회 완료",
-            user,
-            HttpStatus.OK
-        ));
-    }
-
-    @GetMapping("/internal/email/{email}")
-    @PreAuthorize("hasRole('MASTER')")
-    public User getUserByEmail(
-        @PathVariable("email") String email
-    ) {
-
-        return userService.getUserByEmail(email);
     }
 
     @PatchMapping("/my-page")
@@ -166,6 +142,24 @@ public class UserController {
                 status,
                 HttpStatus.OK
             ));
+    }
+
+    @GetMapping("/internal/userId/{userId}")
+    @PreAuthorize("hasRole('MASTER')")
+    public User getUser(
+        @PathVariable("userId") UUID userId
+    ) {
+
+        return userService.getUser(userId);
+    }
+
+    @GetMapping("/internal/email/{email}")
+    @PreAuthorize("hasRole('MASTER')")
+    public User getUserByEmail(
+        @PathVariable("email") String email
+    ) {
+
+        return userService.getUserByEmail(email);
     }
 
 }

--- a/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/controller/UserController.java
@@ -3,6 +3,7 @@ package com.gbg.userservice.presentation.controller;
 import com.gabojago.dto.BaseResponseDto;
 import com.gbg.userservice.application.service.AuthService;
 import com.gbg.userservice.application.service.UserService;
+import com.gbg.userservice.domain.entity.User;
 import com.gbg.userservice.domain.entity.UserStatus;
 import com.gbg.userservice.infrastructure.config.auth.CustomUser;
 import com.gbg.userservice.presentation.dto.request.AdminUpdateRequestDto;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -77,15 +79,29 @@ public class UserController {
                 HttpStatus.OK));
     }
 
-    @GetMapping("/internal/{userId}")
+    @GetMapping("/internal/userId/{userId}")
     @PreAuthorize("hasRole('MASTER')")
-    public ResponseEntity<BaseResponseDto<UserResponseDto>> getUser(
+    public ResponseEntity<BaseResponseDto<User>> getUser(
         @PathVariable("userId") UUID userId
     ) {
 
-        UserResponseDto user = userService.getUser(userId);
+        User user = userService.getUser(userId);
         return ResponseEntity.ok(BaseResponseDto.success(
             "사용자 정보 조회 완료",
+            user,
+            HttpStatus.OK
+        ));
+    }
+
+    @GetMapping("/internal/email/{email}")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<BaseResponseDto<User>> getUserByEmail(
+        @PathVariable("email") String email
+    ) {
+
+        User user = userService.getUserByEmail(email);
+        return ResponseEntity.ok(BaseResponseDto.success(
+            "유저 객체 반환 완료",
             user,
             HttpStatus.OK
         ));

--- a/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/UserResponseDto.java
+++ b/user-service/src/main/java/com/gbg/userservice/presentation/dto/response/UserResponseDto.java
@@ -3,7 +3,6 @@ package com.gbg.userservice.presentation.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gbg.userservice.domain.entity.UserRole;
 import com.gbg.userservice.domain.entity.UserStatus;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +24,7 @@ public class UserResponseDto {
         String username;
         String nickname;
         String slackEmail;
+        boolean slackVerified;
         UUID organization;
         String summary;
         UserRole role;


### PR DESCRIPTION
## 📝 PR 제목
> slack-service & user-service 코드 변경 

---

### 🔍 관련 이슈
- Close #82 

---

### ✨ 작업 내용 요약
> 슬랙 메시지 DM 전송시 메시지는 정상적으로 갔으나 데이터베이스에 저장되지 않는 문제 해결 
> 유저 서비스에서 유저 객체를 반환 할 수 있도록 public User ...~ 식으로 바로 유저 객체 반환 함으로 다른 서비스에서 비교적 편하게 사용할 수 있음
> 슬랙에서 유저 서비스 feignclient로 통신하고, 유저 객체를 가져오면서 검증 하기 성공 
> 유저 객체 반환 컨트롤 유저 아이디로 할 수 있고, 이메일로도 가능함. 

- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.