### PR TITLE
Fix/order feedback 106

### DIFF
--- a/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/gbg/hubservice/infrastructure/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.gbg.hubservice.infrastructure.config.filter.HeaderAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -37,10 +36,10 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // 내부 API 허용 (vendor, product 서비스 접근 용)
                 .requestMatchers("/internal/v1/hubs/**").permitAll()
-                // 허브 권한 규칙
-                .requestMatchers(HttpMethod.POST, "/v1/hubs/**").hasRole("MASTER")
-                .requestMatchers(HttpMethod.PUT, "/v1/hubs/**").hasRole("MASTER")
-                .requestMatchers(HttpMethod.DELETE, "/v1/hubs/**").hasRole("MASTER")
+                .requestMatchers("/v1/hubs/**").permitAll()
+                .requestMatchers("/swagger-ui/**").permitAll()
+                .requestMatchers("/swagger-resources/**").permitAll()
+                .requestMatchers("/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
             )
 

--- a/order-service/src/main/java/com/gbg/orderservice/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/gbg/orderservice/application/service/impl/OrderServiceImpl.java
@@ -7,7 +7,6 @@ import com.gbg.orderservice.application.service.OrderService;
 import com.gbg.orderservice.domain.entity.Order;
 import com.gbg.orderservice.domain.entity.enums.OrderStatus;
 import com.gbg.orderservice.domain.repository.OrderRepository;
-import com.gbg.orderservice.infrastructure.client.DeliveryClient;
 import com.gbg.orderservice.infrastructure.client.HubClient;
 import com.gbg.orderservice.infrastructure.client.VendorClient;
 import com.gbg.orderservice.infrastructure.config.auth.CustomUser;
@@ -42,7 +41,6 @@ public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
     private final ProductRestTemplateClient productRestTemplateClient;
-    private final DeliveryClient deliveryClient;
     private final VendorClient vendorClient;
     private final HubClient hubClient;
     @Autowired
@@ -59,9 +57,7 @@ public class OrderServiceImpl implements OrderService {
 
         // vendor 수령업체 검증
         VendorResponseDto.VendorDto receiverVendor = fetchVendorById(customerVendorId);
-
-//        log.info("reciverVendorId: {}", receiverVendor.isReceiver());
-//        validateIsReceiverVendor(receiverVendor);
+        validateIsReceiverVendor(receiverVendor);
 
         // product 조회, 재고 검증
         ProductResponseDto.ProductDto product = fetchProduct(productId);
@@ -70,7 +66,7 @@ public class OrderServiceImpl implements OrderService {
         // vendor 공급업체 검증
         UUID producerVendorId = product.getVendorId();
         VendorResponseDto.VendorDto producerVendor = fetchVendorById(producerVendorId);
-        // validateIsProducerVendor(producerVendor);
+        validateIsProducerVendor(producerVendor);
 
         UUID producerHubId = producerVendor.getHubId();
 

--- a/order-service/src/main/java/com/gbg/orderservice/application/service/impl/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/gbg/orderservice/application/service/impl/OrderServiceImpl.java
@@ -142,7 +142,7 @@ public class OrderServiceImpl implements OrderService {
     public void postInternalOrderDelivering(CustomUser customUser, UUID orderId) {
         Order order = findOrder(orderId);
 
-        if (customUser.getRole().equals("ROLE_HUB_MANAGER")) {
+        if (customUser.getRole().equals("HUB_MANAGER")) {
             validateHubManagerAccess(customUser, order.getProducerHubId());
         }
 
@@ -150,8 +150,8 @@ public class OrderServiceImpl implements OrderService {
             throw new AppException(OrderErrorCode.ORDER_ALREADY_DELIVERING);
         }
 
-        Order cancelledOrder = order.markDelivering();
-        orderRepository.save(cancelledOrder);
+        Order deliveringOrder = order.markDelivering();
+        orderRepository.save(deliveringOrder);
     }
 
     @Override
@@ -159,7 +159,7 @@ public class OrderServiceImpl implements OrderService {
     public void postInternalOrderDelivered(CustomUser customUser, UUID orderId) {
         Order order = findOrder(orderId);
 
-        if (customUser.getRole().equals("ROLE_HUB_MANAGER")) {
+        if (customUser.getRole().equals("HUB_MANAGER")) {
             validateHubManagerAccess(customUser, order.getProducerHubId());
         }
 
@@ -167,17 +167,16 @@ public class OrderServiceImpl implements OrderService {
             throw new AppException(OrderErrorCode.ORDER_ALREADY_DELIVERED);
         }
 
-        Order cancelledOrder = order.markDelivered();
-        orderRepository.save(cancelledOrder);
+        Order deliveredOrder = order.markDelivered();
+        orderRepository.save(deliveredOrder);
     }
 
     @Override
     @Transactional
     public void postOrderCancel(CustomUser customUser, UUID orderId) {
         Order order = findOrder(orderId);
-        // 마스터랑 공급업체만 취소 가능함.
 
-        if (customUser.getRole().equals("ROLE_VENDOR_MANAGER")) {
+        if (customUser.getRole().equals("VENDOR_MANAGER")) {
             UUID currentUserId = UUID.fromString(customUser.getUserId());
             if (!order.getProducerVendorManagerId().equals(currentUserId)) {
                 throw new AppException(OrderErrorCode.ORDER_ACCESS_DENIED_VENDOR);

--- a/order-service/src/main/java/com/gbg/orderservice/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/gbg/orderservice/domain/repository/OrderRepository.java
@@ -14,10 +14,6 @@ public interface OrderRepository {
 
     Optional<Order> findById(UUID orderId);
 
-    Page<Order> findAll(Pageable pageable);
-
-    Page<Order> findByUserId(UUID userId, Pageable pageable);
-
     Page<GetOrderResponseDto> searchOrders(OrderSearchRequestDto searchRequestDto,
         Pageable pageable,
         String role, UUID userId);

--- a/order-service/src/main/java/com/gbg/orderservice/infrastructure/client/HubClient.java
+++ b/order-service/src/main/java/com/gbg/orderservice/infrastructure/client/HubClient.java
@@ -13,6 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface HubClient {
 
     @GetMapping("/v1/hubs/manager/{hubManagerId}")
-    public ResponseEntity<BaseResponseDto<GetHubResponseDto>> getHubManagerId(
+    ResponseEntity<BaseResponseDto<GetHubResponseDto>> getHubManagerId(
         @Parameter(description = "매니저 UUID") @PathVariable("hubManagerId") UUID hubManagerId);
 }

--- a/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderQueryDslRepository.java
+++ b/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderQueryDslRepository.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface OrderRepositoryCustom {
+public interface OrderQueryDslRepository {
 
     Page<GetOrderResponseDto> searchOrders(OrderSearchRequestDto searchRequestDto,
         Pageable pageable,

--- a/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderQueryDslRepositoryImpl.java
+++ b/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderQueryDslRepositoryImpl.java
@@ -1,0 +1,189 @@
+package com.gbg.orderservice.infrastructure.repository;
+
+import com.gbg.orderservice.domain.entity.Order;
+import com.gbg.orderservice.domain.entity.QOrder;
+import com.gbg.orderservice.presentation.dto.request.OrderSearchRequestDto;
+import com.gbg.orderservice.presentation.dto.response.GetOrderResponseDto;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QOrder order = QOrder.order;
+
+    @Override
+    public Page<GetOrderResponseDto> searchOrders(OrderSearchRequestDto searchRequestDto,
+        Pageable pageable, String role, UUID userId) {
+        // 1) predicate 조립 (role/user + 검색DTO 필터)
+        BooleanExpression predicate = buildPredicate(searchRequestDto, role, userId);
+
+        // 2) 정렬 스펙 생성
+        List<OrderSpecifier<?>> orders = getAllOrderSpecifiers(pageable);
+
+        // 3) 기본 쿼리 (엔티티 리스트 조회용)
+        com.querydsl.jpa.impl.JPAQuery<Order> query = queryFactory
+            .selectFrom(QOrder.order)
+            .where(predicate);
+
+        // 4) 전체 카운트 (조건만 동일하게)
+        Long total = queryFactory
+            .select(QOrder.order.count())
+            .from(QOrder.order)
+            .where(predicate)
+            .fetchOne();
+        if (total == null) {
+            total = 0L;
+        }
+
+        // 5) 페이징 + 정렬 적용하여 실제 데이터 조회
+        List<Order> resultList = query
+            .orderBy(orders.toArray(new OrderSpecifier[0]))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // 6) DTO 매핑
+        List<GetOrderResponseDto> content = resultList.stream()
+            .map(Order::toResponseDto)
+            .collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        if (pageable.getSort() != null) {
+            for (Sort.Order sortOrder : pageable.getSort()) {
+                com.querydsl.core.types.Order direction =
+                    sortOrder.isAscending() ? com.querydsl.core.types.Order.ASC
+                        : com.querydsl.core.types.Order.DESC;
+
+                switch (sortOrder.getProperty()) {
+                    case "createdAt" ->
+                        orders.add(new OrderSpecifier<>(direction, QOrder.order.createdAt));
+                    case "status" ->
+                        orders.add(new OrderSpecifier<>(direction, QOrder.order.status));
+                    default -> { /* 정렬 조건이 없거나 매칭 안되면 무시 */ }
+                }
+            }
+        }
+
+        return orders;
+    }
+
+    /**
+     * predicate 빌더: role/user 체크 + searchRequestDto 기반 필터 결합
+     */
+    private BooleanExpression buildPredicate(OrderSearchRequestDto searchRequestDto, String role,
+        UUID userId) {
+        BooleanExpression finalPredicate = null;
+
+        // 1. 역할 기반 접근 제어 조건
+        BooleanExpression accessFilter = userAccessFilter(searchRequestDto, role, userId);
+        finalPredicate = and(finalPredicate, accessFilter);
+
+        // 2. 검색 DTO 조건
+        BooleanExpression searchFilter = searchDtoFilter(searchRequestDto);
+        finalPredicate = and(finalPredicate, searchFilter);
+
+        return finalPredicate;
+    }
+
+    private BooleanExpression and(BooleanExpression a, BooleanExpression b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        return a.and(b);
+    }
+
+
+    private BooleanExpression userAccessFilter(OrderSearchRequestDto searchRequestDto, String role,
+        UUID userId) {
+        OrderSearchRequestDto.OrderDto od =
+            searchRequestDto != null ? searchRequestDto.getOrder() : null;
+
+        if (od == null) {
+            return null;
+        }
+
+        if ("MASTER".equalsIgnoreCase(role)) {
+            // MASTER: 어떤 필터도 걸지 않고 모든 주문 조회 허용
+            return null;
+        }
+
+        if ("VENDOR_MANAGER".equalsIgnoreCase(role)) {
+            // VENDOR_MANAGER: 수령 업체 ID (receiverVendorId)는 본인 업체 ID와 일치해야 함
+            if (od.getUserId() != null) {
+                return order.userId.eq(od.getUserId());
+            }
+            // 만약 Service에서 ID 설정을 실패했거나 누락됐다면, 접근 금지 처리 (빈 결과)
+            return Expressions.asBoolean(false).isTrue();
+        }
+
+        if ("HUB_MANAGER".equalsIgnoreCase(role)) {
+            // HUB_MANAGER: 허브 ID (producerHubId)는 본인이 관리하는 허브 ID와 일치해야 함
+            // Service에서 이미 producerHubId에 허브 ID가 설정되어 넘어옴
+            if (od.getProducerHubId() != null) {
+                return order.producerHubId.eq(od.getProducerHubId());
+            }
+            // 만약 Service에서 ID 설정을 실패했거나 누락됐다면, 접근 금지 처리
+            return Expressions.asBoolean(false).isTrue();
+        }
+        return null;
+    }
+
+    private BooleanExpression searchDtoFilter(OrderSearchRequestDto searchRequestDto) {
+        if (searchRequestDto == null || searchRequestDto.getOrder() == null) {
+            return null;
+        }
+
+        OrderSearchRequestDto.OrderDto od = searchRequestDto.getOrder();
+        BooleanExpression p = null;
+
+        if (od.getUserId() != null) {
+            p = and(p, order.userId.eq(od.getUserId()));
+        }
+        if (od.getProducerVendorId() != null) {
+            p = and(p, order.producerVendorId.eq(od.getProducerVendorId()));
+        }
+        if (od.getReceiverVendorId() != null) {
+            p = and(p, order.receiverVendorId.eq(od.getReceiverVendorId()));
+        }
+        if (od.getProductId() != null) {
+            p = and(p, order.productId.eq(od.getProductId()));
+        }
+        if (od.getStatus() != null) {
+            p = and(p, order.status.eq(od.getStatus()));
+        }
+        if (od.getDateFrom() != null) {
+            p = and(p, order.createdAt.goe(od.getDateFrom().atStartOfDay()));
+        }
+        if (od.getDateTo() != null) {
+            p = and(p, order.createdAt.loe(od.getDateTo().atTime(23, 59, 59)));
+        }
+        if (od.getProducerHubId() != null) {
+            p = and(p, order.producerHubId.eq(od.getProducerHubId()));
+        }
+
+        return p;
+    }
+}

--- a/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/gbg/orderservice/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,32 +1,23 @@
 package com.gbg.orderservice.infrastructure.repository;
 
 import com.gbg.orderservice.domain.entity.Order;
-import com.gbg.orderservice.domain.entity.QOrder;
 import com.gbg.orderservice.domain.repository.OrderRepository;
 import com.gbg.orderservice.presentation.dto.request.OrderSearchRequestDto;
 import com.gbg.orderservice.presentation.dto.response.GetOrderResponseDto;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 @RequiredArgsConstructor
-public class OrderRepositoryImpl implements OrderRepository, OrderRepositoryCustom {
+public class OrderRepositoryImpl implements OrderRepository {
 
     private final OrderJpaRepository orderJpaRepository;
-    private final JPAQueryFactory queryFactory;
+    private final OrderQueryDslRepository orderQueryDslRepository;
 
     @Override
     public Order save(Order order) {
@@ -39,153 +30,10 @@ public class OrderRepositoryImpl implements OrderRepository, OrderRepositoryCust
     }
 
     @Override
-    public Page<Order> findAll(Pageable pageable) {
-        return orderJpaRepository.findAll(pageable);
-    }
-
-    @Override
-    public Page<Order> findByUserId(UUID userId, Pageable pageable) {
-        return orderJpaRepository.findByUserId(userId, pageable);
-    }
-
-    @Override
     public Page<GetOrderResponseDto> searchOrders(OrderSearchRequestDto searchRequestDto,
         Pageable pageable, String role, UUID userId) {
-        // 1) predicate 조립 (role/user + 검색DTO 필터)
-        BooleanExpression predicate = buildPredicate(searchRequestDto, role, userId);
-
-        // 2) 정렬 스펙 생성
-        List<OrderSpecifier<?>> orders = getAllOrderSpecifiers(pageable);
-
-        // 3) 기본 쿼리 (엔티티 리스트 조회용)
-        com.querydsl.jpa.impl.JPAQuery<Order> query = queryFactory
-            .selectFrom(QOrder.order)
-            .where(predicate);
-
-        // 4) 전체 카운트 (조건만 동일하게)
-        Long total = queryFactory
-            .select(QOrder.order.count())
-            .from(QOrder.order)
-            .where(predicate)
-            .fetchOne();
-        if (total == null) {
-            total = 0L;
-        }
-
-        // 5) 페이징 + 정렬 적용하여 실제 데이터 조회
-        List<Order> resultList = query
-            .orderBy(orders.toArray(new OrderSpecifier[0]))
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
-
-        // 6) DTO 매핑
-        List<GetOrderResponseDto> content = resultList.stream()
-            .map(Order::toResponseDto)
-            .collect(Collectors.toList());
-
-        return new PageImpl<>(content, pageable, total);
+        return orderQueryDslRepository.searchOrders(searchRequestDto, pageable, role, userId);
     }
 
-    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
-        List<OrderSpecifier<?>> orders = new ArrayList<>();
-
-        if (pageable.getSort() != null) {
-            for (Sort.Order sortOrder : pageable.getSort()) {
-                com.querydsl.core.types.Order direction =
-                    sortOrder.isAscending() ? com.querydsl.core.types.Order.ASC
-                        : com.querydsl.core.types.Order.DESC;
-
-                switch (sortOrder.getProperty()) {
-                    case "createdAt" ->
-                        orders.add(new OrderSpecifier<>(direction, QOrder.order.createdAt));
-                    case "status" ->
-                        orders.add(new OrderSpecifier<>(direction, QOrder.order.status));
-                    default -> { /* 정렬 조건이 없거나 매칭 안되면 무시 */ }
-                }
-            }
-        }
-
-        return orders;
-    }
-
-    /**
-     * predicate 빌더: role/user 체크 + searchRequestDto 기반 필터 결합
-     */
-    private BooleanExpression buildPredicate(OrderSearchRequestDto searchRequestDto, String role,
-        UUID userId) {
-        BooleanExpression p = null;
-
-        // role/user 체크
-        BooleanExpression userExpr = userCheck(role, userId);
-        p = and(p, userExpr);
-
-        // searchRequestDto 내부 필터가 있는 경우 처리 (안정적으로 null 체크)
-        if (searchRequestDto != null && searchRequestDto.getOrder() != null) {
-            OrderSearchRequestDto.OrderDto od = searchRequestDto.getOrder();
-
-            if (od.getUserId() != null) {
-                p = and(p, QOrder.order.userId.eq(od.getUserId()));
-            }
-            if (od.getProducerVendorId() != null) {
-                p = and(p, QOrder.order.producerVendorId.eq(od.getProducerVendorId()));
-            }
-            if (od.getReceiverVendorId() != null) {
-                p = and(p, QOrder.order.receiverVendorId.eq(od.getReceiverVendorId()));
-            }
-            if (od.getProductId() != null) {
-                p = and(p, QOrder.order.productId.eq(od.getProductId()));
-            }
-            if (od.getStatus() != null) {
-                p = and(p, QOrder.order.status.eq(od.getStatus()));
-            }
-            if (od.getDateFrom() != null) {
-                p = and(p, QOrder.order.createdAt.goe(od.getDateFrom().atStartOfDay()));
-            }
-            if (od.getDateTo() != null) {
-                // dateTo 끝날짜의 마지막 시각까지 포함하려면 다음과 같이 처리
-                p = and(p, QOrder.order.createdAt.loe(od.getDateTo().atTime(23, 59, 59)));
-            }
-            // 만약 orderItemIds 같은 리스트 필터가 있으면 아래처럼 추가 (타입/필드명 검토 필요)
-            // p = and(p, orderItemIdsIn(od.getOrderItemIds()));
-        }
-
-        return p;
-    }
-
-    /**
-     * null-safe AND 결합 헬퍼
-     */
-    private BooleanExpression and(BooleanExpression a, BooleanExpression b) {
-        if (a == null) {
-            return b;
-        }
-        if (b == null) {
-            return a;
-        }
-        return a.and(b);
-    }
-
-    /**
-     * 기존 userCheck 수정: createdBy는 UUID 타입이므로 변환 후 비교 (파싱 실패 시 null 반환 -> 필터 없음)
-     */
-    private BooleanExpression userCheck(String role, UUID userId) {
-        if (role == null) {
-            return null;
-        }
-        if ("MEMBER".equalsIgnoreCase(role)) {
-            if (userId == null) {
-                return null;
-            }
-            try {
-                return QOrder.order.createdBy.eq(userId);
-            } catch (IllegalArgumentException e) {
-                // userId가 UUID 형식이 아니면 필터 적용 안함(또는 필요시 예외 던지기)
-                return null;
-            }
-        }
-        // ROLE이 MEMBER가 아니면 필터 없음 (관리자 등 전체 조회 허용)
-        return null;
-    }
 
 }

--- a/order-service/src/main/java/com/gbg/orderservice/presentation/advice/OrderErrorCode.java
+++ b/order-service/src/main/java/com/gbg/orderservice/presentation/advice/OrderErrorCode.java
@@ -11,7 +11,6 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_FORBIDDEN("ORDER001", "해당 주문에 접근할 수 없습니다.", HttpStatus.FORBIDDEN),
     ORDER_PRODUCT_NOT_FOUND("ORDER002", "주문 상품 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     ORDER_PRODUCT_OUT_OF_STOCK("ORDER003", "상품 재고가 부족합니다.", HttpStatus.BAD_REQUEST),
-    ORDER_INVALID_QUANTITY("ORDER004", "주문 수량이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     ORDER_BAD_REQUEST("ORDER004", "잘못된 주문 요청입니다.", HttpStatus.BAD_REQUEST),
     ORDER_ALREADY_DELIVERING("ORDER005", "이미 배송 시작한 주문입니다.", HttpStatus.BAD_REQUEST),
     ORDER_ALREADY_DELIVERED("ORDER006", "이미 배송 완료한 주문입니다.", HttpStatus.BAD_REQUEST),

--- a/order-service/src/main/java/com/gbg/orderservice/presentation/dto/request/OrderSearchRequestDto.java
+++ b/order-service/src/main/java/com/gbg/orderservice/presentation/dto/request/OrderSearchRequestDto.java
@@ -29,7 +29,7 @@ public class OrderSearchRequestDto {
         private UUID userId;
 
         @Schema(description = "공급 업체 담당 허브 UUID", example = "ac3b722b-a5c0-477f-a180-288e92481067")
-        private UUID hubId;
+        private UUID producerHubId;
 
         @Schema(description = "공급 업체 UUID", example = "7a3d48b4-6d2a-4b89-8bfa-91c9d4b9e123")
         private UUID producerVendorId;

--- a/order-service/src/main/java/com/gbg/orderservice/presentation/dto/response/GetOrderResponseDto.java
+++ b/order-service/src/main/java/com/gbg/orderservice/presentation/dto/response/GetOrderResponseDto.java
@@ -26,6 +26,9 @@ public class GetOrderResponseDto {
         @Schema(description = "주문자 ID", example = "06432270-2fb0-4a94-9e6c-effdb399d6c3")
         private final UUID userId;
 
+        @Schema(description = "공급 허브 ID", example = "")
+        private final UUID producerHubId;
+
         @Schema(description = "생산자 업체 ID", example = "7f6e5d4c-3b2a-1908-7654-3210fedcba98")
         private final UUID producerVendorId;
 
@@ -54,6 +57,7 @@ public class GetOrderResponseDto {
             return OrderDto.builder()
                 .id(order.getId())
                 .userId(order.getUserId())
+                .producerHubId(order.getProducerHubId())
                 .producerVendorId(order.getProducerVendorId())
                 .receiverVendorId(order.getReceiverVendorId())
                 .deliveryId(order.getDeliveryId())

--- a/order-service/src/main/java/com/gbg/orderservice/presentation/dto/response/VendorResponseDto.java
+++ b/order-service/src/main/java/com/gbg/orderservice/presentation/dto/response/VendorResponseDto.java
@@ -22,8 +22,8 @@ public class VendorResponseDto {
         private String name;
         private UUID hubId;
         private UUID vendorManagerId;
-        private boolean isSupplier;
-        private boolean isReceiver;
+        private boolean supplier;
+        private boolean receiver;
         private String address;
     }
 


### PR DESCRIPTION
## 📝 PR 제목
> 간단하고 명확하게 변경 내용을 요약해주세요.

---
* 주문 서비스의 OrderServiceImpl.java > searchOrders의 권한 필터 부분 ✅
-> 역할별 필터 값을 builder에 설정만 하고 최종 DTO나 userId에 반영하지 않은 채로 UUID.randomUUID()를 전달하고 있어서 QueryDSL 조건이 실제로 적용되고 있지 않습니다.

해결 : infrastructure 계층에서 OrderQueryDslRepository, OrderQueryDslRepositoryImpl을 만들어서 queryDsl문 작성

* 주문 서비스의 OrderServiceImpl.java > postInternalOrderDelivered 부분
-> customUser.getRole().equals("ROLE_HUB_MANAGER") 등으로 처리되어 있는데, 실제 ROLE의 경우 HUB_MANAGER으로 구성되어 있을 것이기 때문에 제대로 작동하지 않을 가능성이 높습니다. ✅
-> 메소드명과 다르게 Order cancelledOrder = order.markDelivered(); 등의 변수를 사용하고 있습니다. 변수명을 잘못 사용할 경우, 혼란을 가져올 수 있으니 주의해서 작성해주세요. 
 ✅

해결: role 체크 "ROLE_"접두사 제거, 변수명 제거

* 주문/배송 에러 코드 중복 ✅
-> ORDER004, ORDER007, DELIVERY003 에러코드가 서로 다른 메세지에 재사용되고 있습니다. 고유한 코드를 구성 할 수 있도록 팀에서 컨벤션을 잘 정하는게 중요할 것 같습니다.

해결: 사용하지 않는 에러코드 삭제

* 수령업체/공급업체 확인하는 로직 추가


### 🔍 관련 이슈
- Close #106

---

### ✨ 작업 내용 요약
> 어떤 변경이 이루어졌는지 간단히 설명해주세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- hub-service securityConfig 수정했습니다.
  - .requestMatchers("/internal/v1/hubs/**").permitAll()
                .requestMatchers("/v1/hubs/**").permitAll() 권한으로 수정

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---
* master가 조회하면 모든 주문 내역을 볼 수 있음 (11개)
  * orderId를 지정하여 검색할 수도 있음 (2개)
* 수령업체는 본인의 주문 내역 조회할 수 있음
  * userId를 내부에서 지정함. 
  

<img width="1557" height="808" alt="image (14)" src="https://github.com/user-attachments/assets/629e9b8a-fbdb-4300-9e47-f87d4d749811" />
<img width="953" height="837" alt="image (15)" src="https://github.com/user-attachments/assets/c5388acb-fdc6-4975-b460-1047646cd219" />



### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.